### PR TITLE
- added "CreateSubdirectories" parameter to the "RollingFileTraceListner"

### DIFF
--- a/src/Essential.Diagnostics.RollingFileTraceListener/IO/FileSystem.cs
+++ b/src/Essential.Diagnostics.RollingFileTraceListener/IO/FileSystem.cs
@@ -8,6 +8,13 @@ namespace Essential.IO
     public class FileSystem : IFileSystem
     {
         /// <summary>
+        ///     Gets or sets the value indicating whether all subdirectories in full file path
+        ///     should be checked for existence and re-created if missed
+        ///     before opening the file. Default value is <c>False</c>.
+        /// </summary>
+        public bool CreateSubdirectories { get; set; }
+
+        /// <summary>
         /// Opens a System.IO.FileStream on the specified path, 
         /// having the specified mode with read, write, or read/write access
         /// and the specified sharing option.
@@ -19,6 +26,13 @@ namespace Essential.IO
         /// <returns></returns>
         public Stream Open(string path, FileMode mode, FileAccess access, FileShare share)
         {
+            if (CreateSubdirectories)
+            {
+                // Making sure that all subdirectories in file path exists
+                var directory = Path.GetDirectoryName(path);
+                Directory.CreateDirectory(directory);
+            }
+
             return File.Open(path, mode, access, share);
         }
     }

--- a/src/Essential.Diagnostics.RollingFileTraceListener/IO/IFileSystem.cs
+++ b/src/Essential.Diagnostics.RollingFileTraceListener/IO/IFileSystem.cs
@@ -8,6 +8,13 @@ namespace Essential.IO
     public interface IFileSystem
     {
         /// <summary>
+        ///     Gets or sets the value indicating whether all subdirectories in full file path
+        ///     should be checked for existence and re-created if missed
+        ///     before opening the file. Default value is <c>False</c>.
+        /// </summary>
+        bool CreateSubdirectories { get; set; }
+
+        /// <summary>
         /// Opens a System.IO.FileStream on the specified path, 
         /// having the specified mode with read, write, or read/write access
         /// and the specified sharing option.

--- a/src/Tests/Essential.Diagnostics.RollingFileTraceListener.Tests/Utility/MockFileSystem.cs
+++ b/src/Tests/Essential.Diagnostics.RollingFileTraceListener.Tests/Utility/MockFileSystem.cs
@@ -7,6 +7,8 @@ namespace Essential.Diagnostics.Tests.Utility
 {
     public class MockFileSystem : IFileSystem
     {
+        public bool CreateSubdirectories { get; set; }
+
         public IList<Tuple<string,MemoryStream>> OpenedItems = new List<Tuple<string,MemoryStream>>();
 
         public Stream Open(string path, FileMode mode, FileAccess access, FileShare share)


### PR DESCRIPTION
Added **CreateSubdirectories** parameter to the **RollingFileTraceListener** with default set to `false` to mimic current behavior of the listener (which will throw `DirectoryNotFoundException` in case of any sub-directories of the full file path are not exist in the system), but setting it to `true` make it possible to have `initializeData` template specified for example like this:

`{AppData}\LogFiles\{DateTime:yyyy-MM}\{DateTime:dd}\YourApplication.log`